### PR TITLE
Allow specify custom external commands for process interaction

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ Quick guide:
 
  1. Install all dependencies: gcc, make, libsdl, sdl_mixer, sdl_net, python.
  2. `cd trunk && ./configure && make`
+ 4. Get a copy of Doom, to copy the file Doom2.wad.
  3. Action! `./src/psdoom`
 
 Find more information in:
@@ -37,9 +38,7 @@ services (AWS, heroku, vmware, etc).
 For that, you only need to override these environment variables:
 
  * PSDOOMPSCMD List the processes. The command must print one space separated 
-   line per process with the format: `<user> <pid> <processname> <is_daemon=[1|0]>
-
-   For example:
+   line per process with the format: `<user> <pid> <processname> <is_daemon=[1|0]>`
 
     keymon 29 web4 1
     keymon 30 web3 1
@@ -54,9 +53,9 @@ For that, you only need to override these environment variables:
 
 For example, in contrib you can find a script that interacts with cloudfoundry:
 
-    PSDOOMPSCMD="./psdoomctl-cf/psdoomctl ps" \
+    PSDOOMPSCMD="./contrib/psdoom-cf-ctl ps" \
     PSDOOMRENICECMD="true" \
-    PSDOOMKILLCMD="./psdoomctl-cf/psdoomctl kill" \
+    PSDOOMKILLCMD="./contrib/psdoom-cf-ctl kill" \
     ./trunk/src/psdoom
 
 

--- a/README.md
+++ b/README.md
@@ -3,4 +3,63 @@ psdoom-ng
 
 psdoom-ng is a First Person Shooter operating system process killer based on psDooM and Chocolate Doom.
 
+
+Compile and usage
+-----------------
+
+Quick guide: 
+
+ 1. Install all dependencies: gcc, make, libsdl, sdl_mixer, sdl_net, python.
+ 2. `cd trunk && ./configure && make`
+ 3. Action! `./src/psdoom`
+
+Find more information in:
+ * trunk/COMPILE
+ * trunk/CMDLINE
+ * trunk/psdoom/README (specific options and instructions to find your processess)
+
+Mac OS X
+---------
+
 Now with support for Mac OS X!
+
+It is recommended use brew to install the depenedencies.
+
+
+Support for external process source
+-----------------------------------
+
+You can use external commands as interface to retrieve, renice and kill process.
+
+This makes it easy to adapt the tool to your needs, or even integrate it with external
+services (AWS, heroku, vmware, etc).
+
+For that, you only need to override these environment variables:
+
+ * PSDOOMPSCMD List the processes. The command must print one space separated 
+   line per process with the format: `<user> <pid> <processname> <is_daemon=[1|0]>
+
+   For example:
+
+    keymon 29 web4 1
+    keymon 30 web3 1
+    keymon 31 adis3 1
+    keymon 32 core15 1
+    keymon 20 core2 1
+
+ * PSDOOMRENICECMD Command to renice the process. Will get the pid as argument
+
+ * PSDOOMKILLCMD Command to kill the process. Will get the pid as argument
+
+
+For example, in contrib you can find a script that interacts with cloudfoundry:
+
+    PSDOOMPSCMD="./psdoomctl-cf/psdoomctl ps" \
+    PSDOOMRENICECMD="true" \
+    PSDOOMKILLCMD="./psdoomctl-cf/psdoomctl kill" \
+    ./trunk/src/psdoom
+
+
+NOTE: psdoom does a synchronous call to the external commands (mono-thread). If your
+command takes too long, you will feel hipcuts in the game. Try to make your commands
+respond really fast! 

--- a/README.md
+++ b/README.md
@@ -53,10 +53,11 @@ For that, you only need to override these environment variables:
 
 For example, in contrib you can find a script that interacts with cloudfoundry:
 
+    cd trunk
     PSDOOMPSCMD="./contrib/psdoom-cf-ctl ps" \
     PSDOOMRENICECMD="true" \
     PSDOOMKILLCMD="./contrib/psdoom-cf-ctl kill" \
-    ./trunk/src/psdoom
+    ./src/psdoom
 
 
 NOTE: psdoom does a synchronous call to the external commands (mono-thread). If your

--- a/README.md
+++ b/README.md
@@ -1,0 +1,6 @@
+psdoom-ng
+=========
+
+psdoom-ng is a First Person Shooter operating system process killer based on psDooM and Chocolate Doom.
+
+Now with support for Mac OS X!

--- a/trunk/contrib/psdoom-cf-ctl
+++ b/trunk/contrib/psdoom-cf-ctl
@@ -1,0 +1,57 @@
+#!/bin/sh
+#
+# Command line tool to use psdoom-ng (patched to support external commands)
+# with cloudfoundry. This is just a small proof of concept, it will show
+# all the apps in the current space as processes. 
+#
+# Kill the process in psdoom means delete the app.
+#
+#   PSDOOMPSCMD="./contrib/psdoom-cf-ctl ps" \
+#   PSDOOMRENICECMD="true" \
+#   PSDOOMKILLCMD="./contrib/psdoom-cf-ctl kill" \
+#   ./trunk/src/psdoom
+#
+
+export CF_COLOR=false
+APPS_CACHE_FILE=/tmp/psdoom-cf_apps_pids.txt
+CF_APPS_OUTPUT=/tmp/psdoom-cf_apps_output.txt
+
+# Hacky function to get an pid per app
+get_pid_for_app() {
+	app=$1
+	grep -qe "^$1\$" $APPS_CACHE_FILE &> /dev/null || echo $app >> $APPS_CACHE_FILE
+	nl $APPS_CACHE_FILE | awk "/\t$app\$/ { print \$1 }"
+}
+get_app_for_pid() {
+	pid=$1
+	nl $APPS_CACHE_FILE | awk "/^[ \t]*$pid\t/ { print \$2 }"
+}
+
+if [ "$1" == "ps" ]; then
+        # We use always a cached output, because it is just easier
+	[ ! -f $CF_APPS_OUTPUT ] && touch $CF_APPS_OUTPUT
+	
+	# The running ones are deamons, the stopped ones, are normal guys
+	for app in $(cat $CF_APPS_OUTPUT | grep -e 'started' | cut -f 1 -d ' '); do
+		pid=$(get_pid_for_app $app)
+		echo "$USER $pid $app 1"
+	done
+	for app in $(cat $CF_APPS_OUTPUT | grep -e 'stopped' | cut -f 1 -d ' '); do
+		pid=$(get_pid_for_app $app)
+		echo "$USER $pid $app 0"
+	done
+
+	# Refresh the cache
+	nohup cf apps > $CF_APPS_OUTPUT &
+
+elif [ "$1" == "kill" ]; then
+	app=$(get_app_for_pid $2)
+	get_app_for_pid $2
+	if [ ! -z "$app" ]; then 
+		# delete it from CF
+		cf delete $app -f 1>&2
+		# And from the cache
+		sed -i ""  "/^$app /d" $CF_APPS_OUTPUT 
+	fi
+fi
+echo $0 $@ 1>&2 

--- a/trunk/src/pr_process.c
+++ b/trunk/src/pr_process.c
@@ -204,6 +204,33 @@ root    321   2  -bash
     }
   }
 
+#elif defined(__MACH__)
+
+  f = popen("ps aux | sed '1 d'", "r");
+
+  if (!f) {
+    fprintf(stderr, "ERROR: pr_check could not open ps\n");
+    return;
+  }
+
+  /* Read in all process information.  Exclude the last process in the
+     list (the 'ps' we just ran). */
+
+  while (fgets(buf, 255, f)) {
+    if ( pid != 0 ) {
+       // Check for username validity before adding to pid list.
+       if ( (psallusers || in_ps_userlist(psuser_list_head, username)) &&
+            !(in_ps_userlist(psnotuser_list_head, username)) ) {
+          add_to_pid_list(pid, namebuf, demon);
+       }
+    }
+    sscanf(buf, "%s %d %*f %*f %*d %*d %s %*4c %*s %*s %s",
+          username, &pid,              tty,            namebuf);
+    if (tty[0]=='?')  /* if there is no tty, then it is a daemon */
+      demon = true;
+    else
+      demon = false;
+  }
 // ******************** UNSUPPORTED OS ********************
 #else
   fprintf(stderr, "ERROR: a version of 'ps' with the proper output formatting\n       is not available for this OS.\n");


### PR DESCRIPTION
I added the possibility to specify external commands for process interaction (ps, kill, renice). That way it is much easier to adapt the project to other platforms, but also to get contributions to integrate it to other services (AWS, vmware, etc...) or other cool features (connect via SSH, etc...)

I also added an example that interacts with CloudFoundry.

This PR includes the support for MacOSX
